### PR TITLE
Add operation specific metrics

### DIFF
--- a/lib/aws-dynamo-db.go
+++ b/lib/aws-dynamo-db.go
@@ -233,6 +233,15 @@ var operationalMetricsGroup = []metricsGroup{
 		{MackerelName: "SuccessfulRequestLatency.#.Maximum", Type: metricsTypeMaximum},
 		{MackerelName: "SuccessfulRequestLatency.#.Average", Type: metricsTypeAverage},
 	}},
+	{CloudWatchName: "ThrottledRequests", Metrics: []metric{
+		{MackerelName: "ThrottledRequests.#", Type: metricsTypeSampleCount},
+	}},
+	{CloudWatchName: "SystemErrors", Metrics: []metric{
+		{MackerelName: "SystemErrors.#", Type: metricsTypeSampleCount},
+	}},
+	{CloudWatchName: "UserErrors", Metrics: []metric{
+		{MackerelName: "UserErrors.#", Type: metricsTypeSampleCount},
+	}},
 }
 
 // FetchMetrics fetch the metrics
@@ -314,6 +323,27 @@ func (p DynamoDBPlugin) GraphDefinition() map[string]mp.Graphs {
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "ConditionalCheckFailedRequests", Label: "Counts"},
+			},
+		},
+		"ThrottledRequests": {
+			Label: (labelPrefix + " ThrottledRequests"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "*", Label: "Counts", Stacked: true},
+			},
+		},
+		"SystemErrors": {
+			Label: (labelPrefix + " SystemErrors"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "*", Label: "Counts", Stacked: true},
+			},
+		},
+		"UserErrors": {
+			Label: (labelPrefix + " UserErrors"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "*", Label: "Counts", Stacked: true},
 			},
 		},
 		"SuccessfulRequests": {

--- a/lib/aws-dynamo-db.go
+++ b/lib/aws-dynamo-db.go
@@ -228,7 +228,10 @@ var defaultMetricsGroup = []metricsGroup{
 
 var operationalMetricsGroup = []metricsGroup{
 	{CloudWatchName: "SuccessfulRequestLatency", Metrics: []metric{
-		{MackerelName: "SuccessfulRequestLatency.#.Count", Type: metricsTypeSampleCount},
+		{MackerelName: "SuccessfulRequests.#", Type: metricsTypeSampleCount},
+		{MackerelName: "SuccessfulRequestLatency.#.Minimum", Type: metricsTypeMinimum},
+		{MackerelName: "SuccessfulRequestLatency.#.Maximum", Type: metricsTypeMaximum},
+		{MackerelName: "SuccessfulRequestLatency.#.Average", Type: metricsTypeAverage},
 	}},
 }
 
@@ -313,11 +316,20 @@ func (p DynamoDBPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "ConditionalCheckFailedRequests", Label: "Counts"},
 			},
 		},
+		"SuccessfulRequests": {
+			Label: (labelPrefix + " SuccessfulRequestLatency"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "*", Label: "Counts"},
+			},
+		},
 		"SuccessfulRequestLatency.#": {
 			Label: (labelPrefix + " SuccessfulRequestLatency"),
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
-				{Name: "Count", Label: "Count", Type: "uint64"},
+				{Name: "Minimum", Label: "Min"},
+				{Name: "Maximum", Label: "Max"},
+				{Name: "Average", Label: "Average"},
 			},
 		},
 	}

--- a/lib/aws-dynamo-db.go
+++ b/lib/aws-dynamo-db.go
@@ -223,11 +223,11 @@ func (p DynamoDBPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "WriteThrottleEvents", Label: "Write"},
 			},
 		},
-		"Requests": {
-			Label: (labelPrefix + " Requests"),
+		"ConditionalCheckFailedRequests": {
+			Label: (labelPrefix + " ConditionalCheckFailedRequests"),
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
-				{Name: "ConditionalCheckFailedRequests", Label: "ConditionalCheck Failure"},
+				{Name: "ConditionalCheckFailedRequests", Label: "Counts"},
 			},
 		},
 	}


### PR DESCRIPTION
These metrics takes tableName dimension and operation dimension.
With this implementation this plugin at first does ListMetrics to obtain available dimensions, then get datapoints for them.